### PR TITLE
feat(validation): Support array indexing in JSON path validation

### DIFF
--- a/src/Extractors/JsonExtractor.php
+++ b/src/Extractors/JsonExtractor.php
@@ -44,10 +44,11 @@ class JsonExtractor implements Extractor
         if (empty($this->selector) || $this->selector === '$.') {
             throw new InvalidJsonPathException('JSON path cannot be empty');
         }
-        // Validate the selector ex: $.meta.token
+        // Validate the selector ex: $.meta.token or $.data[0].name
         // Validate the selector follows proper JSON path format
         // Should start with $ followed by dot and valid path segments
-        if (! preg_match('/^\$(\.[a-zA-Z0-9_]+)*$/', $this->selector)) {
+        $pattern = '/^\$(\.[a-zA-Z0-9_]+|\[[0-9]+\])*$/';
+        if (! preg_match($pattern, $this->selector)) {
             throw new InvalidJsonPathException('Invalid JSON path');
         }
 

--- a/tests/Units/JsonExtractorTest.php
+++ b/tests/Units/JsonExtractorTest.php
@@ -57,7 +57,7 @@ class JsonExtractorTest extends TestCase
     {
         $this->expectException(InvalidJsonPathException::class);
         $extractor = new JsonExtractor('testVar', $jsonPath);
-        $extractor->validate(true);
+        $extractor->validate();
     }
 
     public static function invalidJsonPathProvider(): array

--- a/tests/Units/JsonExtractorTest.php
+++ b/tests/Units/JsonExtractorTest.php
@@ -46,6 +46,9 @@ class JsonExtractorTest extends TestCase
             ['with_underscore'],
             ['with.numbers.123'],
             ['mixed.path_with.numbers123'],
+            ['mixed[0].path'],
+            ['mixed[0].path[1]'],
+            ['mixed[0].path[1].with[2].numbers[3]'],
         ];
     }
 
@@ -54,7 +57,7 @@ class JsonExtractorTest extends TestCase
     {
         $this->expectException(InvalidJsonPathException::class);
         $extractor = new JsonExtractor('testVar', $jsonPath);
-        $extractor->validate();
+        $extractor->validate(true);
     }
 
     public static function invalidJsonPathProvider(): array
@@ -67,6 +70,12 @@ class JsonExtractorTest extends TestCase
             ['$invalid.start'],
             ['invalid$.middle'],
             ['path.with.$'],
+            ['$.data[abc]'],
+            ['$.data[0].name[abc]'],
+            ['$.data[0].name[0].'],
+            ['$.data[0].name[0].[1]'],
+            ['$.data[0].name[0].[1].'],
+            ['$.data[0].name[0].[1].name'],
         ];
     }
 


### PR DESCRIPTION
- Updated the JSON path validation regex to allow array indexing (e.g., `$.data[0].attribute`).
- Ensured compatibility with dot notation for nested objects (e.g., `$.data.object.attribute`).
- Improved validation to support mixed array and object paths (e.g., `$.data[0].nested[2].value`).
- Added stricter checks to prevent malformed paths.

Closes #20 